### PR TITLE
Make it easier to use standalone FeedbackSDKClient

### DIFF
--- a/Examples/FeedbackExample/FeedbackExample/SimpleFeedbackFormExample.swift
+++ b/Examples/FeedbackExample/FeedbackExample/SimpleFeedbackFormExample.swift
@@ -10,14 +10,17 @@ import SwiftUI
 
 struct ExampleContainer: View {
   @Environment(\.dismiss) private var dismiss
-  
+
   let config: SimpleFeedbackConfig
-  
+
   var body: some View {
     //TODO: - Replace with your API key
-    SimpleFeedbackForm(appKey: "01b7f627-37c0-43f8-8815-2d730f55134b", config: config, onFeedbackReported: {
-      print("feedback submitted")
-    })
+    SimpleFeedbackForm(
+      appKey: "01b7f627-37c0-43f8-8815-2d730f55134b", config: config,
+      onFeedbackReported: {
+        print("feedback submitted")
+      }
+    )
     .accentColor(.purple)
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {
@@ -30,38 +33,46 @@ struct ExampleContainer: View {
 struct SimpleFeedbackFormExample: View {
   @State var showFeedback: Bool = false
   @State var example: Example = .example1
-  
+
   var body: some View {
     VStack(alignment: .leading) {
       Group {
-        Button("Example", action: {
-          example = .example1
-          showFeedback.toggle()
-        })
-        Button("Example - Pinned Button", action: {
-          example = .example2
-          showFeedback.toggle()
-        })
-        Button("Example - Text field", action: {
-          example = .example3
-          showFeedback.toggle()
-        })
+        Button(
+          "Example",
+          action: {
+            example = .example1
+            showFeedback.toggle()
+          })
+        Button(
+          "Example - Pinned Button",
+          action: {
+            example = .example2
+            showFeedback.toggle()
+          })
+        Button(
+          "Example - Text field",
+          action: {
+            example = .example3
+            showFeedback.toggle()
+          })
       }
       .padding()
       .font(.title2)
-      
+
     }
-    .sheet(isPresented: $showFeedback, content: {
-      if #available(iOS 16.0, *) {
-        NavigationStack {
-          ExampleContainer(config: example.config())
+    .sheet(
+      isPresented: $showFeedback,
+      content: {
+        if #available(iOS 16.0, *) {
+          NavigationStack {
+            ExampleContainer(config: example.config())
+          }
+        } else {
+          NavigationView {
+            ExampleContainer(config: example.config())
+          }
         }
-      } else {
-        NavigationView {
-          ExampleContainer(config: example.config())
-        }
-      }
-    })
+      })
   }
 }
 
@@ -70,7 +81,6 @@ struct ContentView_Previews: PreviewProvider {
     SimpleFeedbackFormExample()
   }
 }
-
 
 enum Example: String, Hashable {
   case example1
@@ -82,11 +92,15 @@ extension Example {
   func config() -> SimpleFeedbackConfig {
     switch self {
     case .example1:
-        .init(title: "Hello", subtitle: "How do you feel about our app?", textDescription: "", showEmojiPicker: true, emojiPickerLabel: "")
+      .init(
+        title: "Hello", subtitle: "How do you feel about our app?", textDescription: "",
+        showEmojiPicker: true, emojiPickerLabel: "")
     case .example2:
-        .init(title: "Hello", subtitle: "How do you feel about our app?", textDescription: "", showEmojiPicker: true, emojiPickerLabel: "", pinSubmitButton: true)
+      .init(
+        title: "Hello", subtitle: "How do you feel about our app?", textDescription: "",
+        showEmojiPicker: true, emojiPickerLabel: "", pinSubmitButton: true)
     case .example3:
-        .init(title: "Hello", subtitle: "How do you feel about our app?", textDescription: "")
+      .init(title: "Hello", subtitle: "How do you feel about our app?", textDescription: "")
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ build: ## Build the library
 
 lint: ## Run swift-lint to format and lint the project
 	@swift-format format -i --configuration ./.swift-format --recursive ./Sources
+	@swift-format format -i --configuration ./.swift-format --recursive ./Tests
+	@swift-format format -i --configuration ./.swift-format --recursive ./Examples
 	@swift-format lint --configuration ./.swift-format --recursive ./Sources
 
 docs: ## Generate DocC output

--- a/Sources/FeedbackBulb.Toolbox/Components/View+TextEditorBackground.swift
+++ b/Sources/FeedbackBulb.Toolbox/Components/View+TextEditorBackground.swift
@@ -11,10 +11,10 @@ struct TextEditorModifiers: ViewModifier {
   @ViewBuilder
   func body(content: Content) -> some View {
     content
-    .scrollableSupportingDarkMode()
-    #if canImport(UIKit)
-      .background(content: { Color(UIColor.secondarySystemGroupedBackground) })
-    #endif
+      .scrollableSupportingDarkMode()
+      #if canImport(UIKit)
+        .background(content: { Color(UIColor.secondarySystemGroupedBackground) })
+      #endif
   }
 }
 

--- a/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackForm.swift
+++ b/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackForm.swift
@@ -10,215 +10,215 @@ import SwiftUI
 
 #if canImport(UIKit)
 
-public struct SimpleFeedbackForm: View {
+  public struct SimpleFeedbackForm: View {
     @StateObject var viewModel: SimpleFeedbackFormViewModel
     @Environment(\.dismiss) private var dismiss
-    
+
     public var body: some View {
-        ZStack(alignment: .bottom) {
-            ScrollView(
-                .vertical,
-                showsIndicators: true
-            ) {
-                VStack(alignment: .leading, spacing: 32) {
-                    VStack(alignment: .leading) {
-                        title
-                        if !viewModel.config.subtitle.isEmpty {
-                            Text(viewModel.config.subtitle)
-                                .bold()
-                        }
-                    }
-                    
-                    if viewModel.config.showEmojiPicker {
-                        VStack(alignment: .leading) {
-                            if !viewModel.config.emojiPickerLabel.isEmpty {
-                                Text(viewModel.config.emojiPickerLabel)
-                                    .bold()
-                            }
-                            EmojiPicker(mood: $viewModel.emoji, items: viewModel.config.emojis)
-                        }
-                    }
-                    
-                    if viewModel.config.showEmail {
-                        VStack(alignment: .leading) {
-                            if !viewModel.config.emailLabel.isEmpty {
-                                Text(viewModel.config.emailLabel)
-                                    .bold()
-                            }
-                            TextField(
-                                text: $viewModel.email, prompt: Text(viewModel.config.emailPlaceholder), label: {}
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .textInputAutocapitalization(.never)
-                        }
-                    }
-                    
-                    VStack(alignment: .leading) {
-                        if !viewModel.config.textLabel.isEmpty {
-                            Text(viewModel.config.textLabel)
-                                .bold()
-                        }
-                        
-                        Text(viewModel.config.textDescription)
-                            .font(.subheadline)
-                        FeedbackTextEditor(
-                            label: viewModel.config.textAccessibilityLabel, text: $viewModel.content
-                        )
-                        .frame(minHeight: 160)
-                    }
-                    
-                    if viewModel.config.showAddImage {
-                        VStack(alignment: .leading) {
-                            if !viewModel.config.addImageLabel.isEmpty {
-                                Text(viewModel.config.addImageLabel)
-                                    .bold()
-                            }
-                            
-                            AttachmentPicker(onAttachmentSelected: { viewModel.imageData = $0 })
-                        }
-                    }
-                    
-                    if !viewModel.config.pinSubmitButton {
-                        self.footer
-                    }
+      ZStack(alignment: .bottom) {
+        ScrollView(
+          .vertical,
+          showsIndicators: true
+        ) {
+          VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading) {
+              title
+              if !viewModel.config.subtitle.isEmpty {
+                Text(viewModel.config.subtitle)
+                  .bold()
+              }
+            }
+
+            if viewModel.config.showEmojiPicker {
+              VStack(alignment: .leading) {
+                if !viewModel.config.emojiPickerLabel.isEmpty {
+                  Text(viewModel.config.emojiPickerLabel)
+                    .bold()
                 }
-                .padding(.horizontal)
-                .if(viewModel.config.pinSubmitButton, transform: { $0.padding(.bottom, 120) })
-                .if(!viewModel.config.pinSubmitButton, transform: { $0.padding(.bottom) })
+                EmojiPicker(mood: $viewModel.emoji, items: viewModel.config.emojis)
+              }
             }
-#if !os(visionOS)
-            .if(viewModel.config.pinSubmitButton, transform: { $0.alwaysBounceVertical(false) })
-#endif
-            
-            if viewModel.config.pinSubmitButton {
-                self.footer
+
+            if viewModel.config.showEmail {
+              VStack(alignment: .leading) {
+                if !viewModel.config.emailLabel.isEmpty {
+                  Text(viewModel.config.emailLabel)
+                    .bold()
+                }
+                TextField(
+                  text: $viewModel.email, prompt: Text(viewModel.config.emailPlaceholder), label: {}
+                )
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+              }
             }
-            
+
+            VStack(alignment: .leading) {
+              if !viewModel.config.textLabel.isEmpty {
+                Text(viewModel.config.textLabel)
+                  .bold()
+              }
+
+              Text(viewModel.config.textDescription)
+                .font(.subheadline)
+              FeedbackTextEditor(
+                label: viewModel.config.textAccessibilityLabel, text: $viewModel.content
+              )
+              .frame(minHeight: 160)
+            }
+
+            if viewModel.config.showAddImage {
+              VStack(alignment: .leading) {
+                if !viewModel.config.addImageLabel.isEmpty {
+                  Text(viewModel.config.addImageLabel)
+                    .bold()
+                }
+
+                AttachmentPicker(onAttachmentSelected: { viewModel.imageData = $0 })
+              }
+            }
+
+            if !viewModel.config.pinSubmitButton {
+              self.footer
+            }
+          }
+          .padding(.horizontal)
+          .if(viewModel.config.pinSubmitButton, transform: { $0.padding(.bottom, 120) })
+          .if(!viewModel.config.pinSubmitButton, transform: { $0.padding(.bottom) })
         }
-        .background(Color(UIColor.systemGroupedBackground))
+        #if !os(visionOS)
+          .if(viewModel.config.pinSubmitButton, transform: { $0.alwaysBounceVertical(false) })
+        #endif
+
+        if viewModel.config.pinSubmitButton {
+          self.footer
+        }
+
+      }
+      .background(Color(UIColor.systemGroupedBackground))
     }
-    
+
     var title: some View {
-        Text(
-            viewModel.config.title
-        )
-        .font(.largeTitle.bold())
-        .multilineTextAlignment(.center)
-        .fixedSize(horizontal: false, vertical: true)
+      Text(
+        viewModel.config.title
+      )
+      .font(.largeTitle.bold())
+      .multilineTextAlignment(.center)
+      .fixedSize(horizontal: false, vertical: true)
     }
-    
+
     @ViewBuilder
     var footer: some View {
-        if viewModel.config.pinSubmitButton {
-            footerPinned
-        } else {
-            footerFixed
-        }
+      if viewModel.config.pinSubmitButton {
+        footerPinned
+      } else {
+        footerFixed
+      }
     }
-    
+
     // Footer view which moves together with the soft keyboard when it appears on screen
     var footerPinned: some View {
-        HStack(alignment: .bottom) {
-            Button(
-                action: {
-                    Task {
-                        try? await self.viewModel.primaryAction()
-                    }
-                    self.dismiss()
-                },
-                label: {
-                    Text(viewModel.config.submitButtonLabel)
-                }
-            )
-            .buttonStyle(
-                SubmitButtonStyle()
-            )
-            .padding()
-            .background(
-                Rectangle()
-                    .fill(Color(UIColor.systemBackground))
-                    .ignoresSafeArea(.all, edges: .bottom)
-            )
-            .shadow(color: Color.black.opacity(0.16), radius: 6, x: 0, y: 3)
-        }
+      HStack(alignment: .bottom) {
+        Button(
+          action: {
+            Task {
+              try? await self.viewModel.primaryAction()
+            }
+            self.dismiss()
+          },
+          label: {
+            Text(viewModel.config.submitButtonLabel)
+          }
+        )
+        .buttonStyle(
+          SubmitButtonStyle()
+        )
+        .padding()
+        .background(
+          Rectangle()
+            .fill(Color(UIColor.systemBackground))
+            .ignoresSafeArea(.all, edges: .bottom)
+        )
+        .shadow(color: Color.black.opacity(0.16), radius: 6, x: 0, y: 3)
+      }
     }
-    
+
     // Footer view which remains in a fixed place, under the soft keyboard on screen
     var footerFixed: some View {
-        HStack {
-            Button(
-                action: {
-                    Task {
-                        try? await self.viewModel.primaryAction()
-                    }
-                    self.dismiss()
-                },
-                label: {
-                    Text(viewModel.config.submitButtonLabel)
-                }
-            )
-            
-            .buttonStyle(
-                SubmitButtonStyle()
-            )
-        }
-    }
-}
+      HStack {
+        Button(
+          action: {
+            Task {
+              try? await self.viewModel.primaryAction()
+            }
+            self.dismiss()
+          },
+          label: {
+            Text(viewModel.config.submitButtonLabel)
+          }
+        )
 
-extension SimpleFeedbackForm {
+        .buttonStyle(
+          SubmitButtonStyle()
+        )
+      }
+    }
+  }
+
+  extension SimpleFeedbackForm {
     public init(appKey: String, onFeedbackReported: (() -> Void)? = nil) {
-        self.init(
-            viewModel: SimpleFeedbackFormViewModel(
-                appKey: appKey, onFeedbackReported: onFeedbackReported))
+      self.init(
+        viewModel: SimpleFeedbackFormViewModel(
+          appKey: appKey, onFeedbackReported: onFeedbackReported))
     }
     public init(
-        appKey: String, config: SimpleFeedbackConfig, onFeedbackReported: (() -> Void)? = nil
+      appKey: String, config: SimpleFeedbackConfig, onFeedbackReported: (() -> Void)? = nil
     ) {
-        self.init(
-            viewModel: SimpleFeedbackFormViewModel(
-                appKey: appKey, config, onFeedbackReported: onFeedbackReported))
+      self.init(
+        viewModel: SimpleFeedbackFormViewModel(
+          appKey: appKey, config, onFeedbackReported: onFeedbackReported))
     }
-}
+  }
 
-struct FooterPadding {
-#if os(iOS) || os(visionOS)
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
-#endif
-}
+  struct FooterPadding {
+    #if os(iOS) || os(visionOS)
+      @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+      @Environment(\.verticalSizeClass) private var verticalSizeClass
+    #endif
+  }
 
-extension FooterPadding: ViewModifier {
+  extension FooterPadding: ViewModifier {
     func body(
-        content: Content
+      content: Content
     ) -> some View {
-        if self.horizontalSizeClass == .regular {
-            content.padding(
-                .init(
-                    top: 0,
-                    leading: 150,
-                    bottom: 50,
-                    trailing: 150
-                )
-            )
-        } else if self.verticalSizeClass == .compact {
-            content.padding(
-                .init(
-                    top: 0,
-                    leading: 40,
-                    bottom: 35,
-                    trailing: 40
-                )
-            )
-        } else {
-            content.padding(
-                .init(
-                    top: 0,
-                    leading: 20,
-                    bottom: 80,
-                    trailing: 20
-                )
-            )
-        }
+      if self.horizontalSizeClass == .regular {
+        content.padding(
+          .init(
+            top: 0,
+            leading: 150,
+            bottom: 50,
+            trailing: 150
+          )
+        )
+      } else if self.verticalSizeClass == .compact {
+        content.padding(
+          .init(
+            top: 0,
+            leading: 40,
+            bottom: 35,
+            trailing: 40
+          )
+        )
+      } else {
+        content.padding(
+          .init(
+            top: 0,
+            leading: 20,
+            bottom: 80,
+            trailing: 20
+          )
+        )
+      }
     }
-}
+  }
 #endif

--- a/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackFormViewModel.swift
+++ b/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackFormViewModel.swift
@@ -25,7 +25,7 @@ final class SimpleFeedbackFormViewModel: ObservableObject {
 
   func primaryAction() async throws {
     var client = FeedbackSDKClient(
-      appKey: appKey, instanceURL: URL(string: "https://feedbackbulb.com")!)
+      appKey: appKey)
     if config.debugRequests {
       client.debugOn()
     } else {

--- a/Sources/FeedbackBulb/FeedbackSDKClient.swift
+++ b/Sources/FeedbackBulb/FeedbackSDKClient.swift
@@ -20,6 +20,14 @@ public struct FeedbackSDKClient {
   internal let validStatusCodes = 200..<300
 
   public init(
+    appKey: String
+  ) {
+    self.session = URLSession.shared
+    self.instanceURL = URL(string: "https://feedbackbulb.com")!
+    self.appKey = appKey
+  }
+
+  public init(
     appKey: String,
     session: URLSession = URLSession.shared,
     instanceURL: URL

--- a/Tests/FeedbackBulbTests/FeedbackSDKClientTests.swift
+++ b/Tests/FeedbackBulbTests/FeedbackSDKClientTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class FeedbackSDKClientTests: XCTestCase {
     func testRequestBuilder() async throws {
-        let sut = FeedbackSDKClient(appKey: "01b7f627-37c0-43f8-8815-2d730f55134b", instanceURL: URL(string: "https://feedbackbulb.com")!)
+        let sut = FeedbackSDKClient(appKey: "01b7f627-37c0-43f8-8815-2d730f55134b")
         
         try await sut.submitFeedback(content: "hello from a test")
     }

--- a/Tests/FeedbackBulbTests/FeedbackSDKClientTests.swift
+++ b/Tests/FeedbackBulbTests/FeedbackSDKClientTests.swift
@@ -1,10 +1,11 @@
 import XCTest
+
 @testable import FeedbackBulb
 
 final class FeedbackSDKClientTests: XCTestCase {
-    func testRequestBuilder() async throws {
-        let sut = FeedbackSDKClient(appKey: "01b7f627-37c0-43f8-8815-2d730f55134b")
-        
-        try await sut.submitFeedback(content: "hello from a test")
-    }
+  func testRequestBuilder() async throws {
+    let sut = FeedbackSDKClient(appKey: "01b7f627-37c0-43f8-8815-2d730f55134b")
+
+    try await sut.submitFeedback(content: "hello from a test")
+  }
 }

--- a/Tests/FeedbackBulbTests/Helpers/XCTestCase+LocalContent.swift
+++ b/Tests/FeedbackBulbTests/Helpers/XCTestCase+LocalContent.swift
@@ -1,6 +1,6 @@
 //
 //  XCTestCase+LocalContent.swift
-//  
+//
 //
 //  Created by konstantin on 30/10/2022.
 //
@@ -9,12 +9,12 @@ import Foundation
 import XCTest
 
 extension XCTestCase {
-    func URLForResource(fileName: String, withExtension: String) -> URL {
-        return Bundle.module.url(forResource: fileName, withExtension: withExtension)!
-    }
-    
-    func localContent(_ fileName: String, _ fileExtension: String = "json") -> Data {
-        let url = URLForResource(fileName: fileName, withExtension: fileExtension)
-        return try! Data.init(contentsOf: url)
-    }
+  func URLForResource(fileName: String, withExtension: String) -> URL {
+    return Bundle.module.url(forResource: fileName, withExtension: withExtension)!
+  }
+
+  func localContent(_ fileName: String, _ fileExtension: String = "json") -> Data {
+    let url = URLForResource(fileName: fileName, withExtension: fileExtension)
+    return try! Data.init(contentsOf: url)
+  }
 }

--- a/Tests/FeedbackBulbTests/MultipartFormTests.swift
+++ b/Tests/FeedbackBulbTests/MultipartFormTests.swift
@@ -1,95 +1,105 @@
 import XCTest
+
 @testable import FeedbackBulb
 
 final class MultipartFormTests: XCTestCase {
-    func testExample() throws {
-        let imageData = localContent("2", "png")
-        let formData = localContent("exampleForm", "")
-        
-        let form = MultipartForm(parts: [
-            MultipartForm.Part(name: "a", value: "1"),
-            MultipartForm.Part(name: "b", data: imageData, filename: "b.txt", contentType: "text/plain"),
-            MultipartForm.Part(name: "c", value: "3"),
-        ], boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-        
-        XCTAssertEqual(form.bodyData, formData)
-    }
-    
-    func testContentType() {
-        let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-        
-        XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-    }
+  func testExample() throws {
+    let imageData = localContent("2", "png")
+    let formData = localContent("exampleForm", "")
 
-    func testMultipartMixedType() {
-        let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .mixed)
+    let form = MultipartForm(
+      parts: [
+        MultipartForm.Part(name: "a", value: "1"),
+        MultipartForm.Part(
+          name: "b", data: imageData, filename: "b.txt", contentType: "text/plain"),
+        MultipartForm.Part(name: "c", value: "3"),
+      ], boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
 
-        XCTAssertEqual(form.contentType, "multipart/mixed; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-    }
+    XCTAssertEqual(form.bodyData, formData)
+  }
 
-    func testMultipartFormDataType() {
-        let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .formData)
+  func testContentType() {
+    let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
 
-        XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-    }
-    
-    func testSubscriptGet() {
-        let form = MultipartForm(parts: [
-            MultipartForm.Part(name: "a", value: "1"),
-            MultipartForm.Part(name: "a", value: "2"),
-            MultipartForm.Part(name: "c", value: "3"),
-        ])
-        
-        XCTAssertEqual(form["a"]?.value, "1")
-        XCTAssertNil(form["b"])
-        XCTAssertEqual(form["c"]?.value, "3")
-    }
-    
-    func testSubscriptSet() {
-        var form = MultipartForm(parts: [
-            MultipartForm.Part(name: "a", value: "1"),
-            MultipartForm.Part(name: "a", value: "2"),
-            MultipartForm.Part(name: "c", value: "3"),
-        ])
-        
-        form["a"] = MultipartForm.Part(name: "a", value: "3")
-        XCTAssertEqual(form["a"]?.value, "3")
-        
-        XCTAssertEqual(form.parts, [
-            MultipartForm.Part(name: "c", value: "3"),
-            MultipartForm.Part(name: "a", value: "3"),
-        ])
-    }
-    
-    func testGetValue() {
-        let part = MultipartForm.Part(name: "a", data: "1".data(using: .utf8)!)
-        
-        XCTAssertEqual(part.value, "1")
-    }
-    
-    func testSetValue() {
-        var part = MultipartForm.Part(name: "a", value: "1")
-        
-        part.value = "2"
-        XCTAssertEqual(part.value, "2")
-        XCTAssertEqual(part.data, "2".data(using: .utf8)!)
-    }
-    
-    func testSetNilValue() {
-        var part = MultipartForm.Part(name: "a", value: "1")
-        
-        part.value = nil
-        XCTAssertEqual(part.value, "")
-        XCTAssertEqual(part.data, Data())
-    }
-    
-    static var allTests = [
-        ("testExample", testExample),
-        ("testContentType", testContentType),
-        ("testSubscriptGet", testSubscriptGet),
-        ("testSubscriptSet", testSubscriptSet),
-        ("testGetValue", testGetValue),
-        ("testSetValue", testSetValue),
-        ("testSetNilValue", testSetNilValue),
-    ]
+    XCTAssertEqual(
+      form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+  }
+
+  func testMultipartMixedType() {
+    let form = MultipartForm(
+      boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .mixed)
+
+    XCTAssertEqual(
+      form.contentType, "multipart/mixed; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+  }
+
+  func testMultipartFormDataType() {
+    let form = MultipartForm(
+      boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .formData)
+
+    XCTAssertEqual(
+      form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+  }
+
+  func testSubscriptGet() {
+    let form = MultipartForm(parts: [
+      MultipartForm.Part(name: "a", value: "1"),
+      MultipartForm.Part(name: "a", value: "2"),
+      MultipartForm.Part(name: "c", value: "3"),
+    ])
+
+    XCTAssertEqual(form["a"]?.value, "1")
+    XCTAssertNil(form["b"])
+    XCTAssertEqual(form["c"]?.value, "3")
+  }
+
+  func testSubscriptSet() {
+    var form = MultipartForm(parts: [
+      MultipartForm.Part(name: "a", value: "1"),
+      MultipartForm.Part(name: "a", value: "2"),
+      MultipartForm.Part(name: "c", value: "3"),
+    ])
+
+    form["a"] = MultipartForm.Part(name: "a", value: "3")
+    XCTAssertEqual(form["a"]?.value, "3")
+
+    XCTAssertEqual(
+      form.parts,
+      [
+        MultipartForm.Part(name: "c", value: "3"),
+        MultipartForm.Part(name: "a", value: "3"),
+      ])
+  }
+
+  func testGetValue() {
+    let part = MultipartForm.Part(name: "a", data: "1".data(using: .utf8)!)
+
+    XCTAssertEqual(part.value, "1")
+  }
+
+  func testSetValue() {
+    var part = MultipartForm.Part(name: "a", value: "1")
+
+    part.value = "2"
+    XCTAssertEqual(part.value, "2")
+    XCTAssertEqual(part.data, "2".data(using: .utf8)!)
+  }
+
+  func testSetNilValue() {
+    var part = MultipartForm.Part(name: "a", value: "1")
+
+    part.value = nil
+    XCTAssertEqual(part.value, "")
+    XCTAssertEqual(part.data, Data())
+  }
+
+  static var allTests = [
+    ("testExample", testExample),
+    ("testContentType", testContentType),
+    ("testSubscriptGet", testSubscriptGet),
+    ("testSubscriptSet", testSubscriptSet),
+    ("testGetValue", testGetValue),
+    ("testSetValue", testSetValue),
+    ("testSetNilValue", testSetNilValue),
+  ]
 }


### PR DESCRIPTION
With this PR, it's now possible to initialise a FeedbackSDKClient instance directly with just the app key:

```swift
let feedbackClient = FeedbackSDKClient(appKey: "XX-XXX-XXXX")
```

This is especially useful for apps creating their own feedback UI.