### PR TITLE
Add environment observer

### DIFF
--- a/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackFormViewModel.swift
+++ b/Sources/FeedbackBulb.Toolbox/Forms/SimpleFeedbackFormViewModel.swift
@@ -32,98 +32,24 @@ final class SimpleFeedbackFormViewModel: ObservableObject {
       client.debugOff()
     }
 
+    var attributes = FeedbackEnvironmentObserver().describeCurrentEnvironment()
+
+    if config.showEmojiPicker, emoji != "" {
+      attributes["emoji"] = emoji
+    }
+
     try await client.submitFeedback(
       content: content, fileName: "image.jpg", file: imageData, mimeType: "image/jpeg",
       email: email,
-      attrs: getAttributes())
+      attrs: attributes)
     #if os(iOS)
       await UINotificationFeedbackGenerator().notificationOccurred(.success)
     #endif
     onFeedbackReported?()
   }
 
-  private func getAttributes() -> [String: String] {
-    let osv = ProcessInfo.processInfo.operatingSystemVersion
-    var attrs = [
-      "app version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
-        as? String ?? "-",
-      "app build": Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion")
-        as? String ?? "-",
-      "os": "\(osv.majorVersion).\(osv.minorVersion).\(osv.patchVersion)",
-      "system": Self.operatingSystem,
-      "model": Self.modelName,
-    ]
-
-    if config.showEmojiPicker, emoji != "" {
-      attrs["emoji"] = emoji
-    }
-
-    return attrs
-  }
-
   @Published var content: String = ""
   @Published var email: String = ""
   @Published var imageData: Data? = nil
   @Published var emoji: String = ""
-
-  /// The modelname as reported by systemInfo.machine
-  /// source: https://github.com/TelemetryDeck/SwiftClient
-  static var modelName: String {
-    #if os(iOS)
-      if #available(iOS 14.0, *) {
-        if ProcessInfo.processInfo.isiOSAppOnMac {
-          var size = 0
-          sysctlbyname("hw.model", nil, &size, nil, 0)
-          var machine = [CChar](repeating: 0, count: size)
-          sysctlbyname("hw.model", &machine, &size, nil, 0)
-          return String(cString: machine)
-        }
-      }
-    #endif
-    #if os(macOS)
-      if #available(macOS 11, *) {
-        let service = IOServiceGetMatchingService(
-          kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
-        var modelIdentifier: String?
-        if let modelData = IORegistryEntryCreateCFProperty(
-          service, "model" as CFString, kCFAllocatorDefault, 0
-        ).takeRetainedValue() as? Data {
-          if let modelIdentifierCString = String(data: modelData, encoding: .utf8)?.cString(
-            using: .utf8)
-          {
-            modelIdentifier = String(cString: modelIdentifierCString)
-          }
-        }
-        IOObjectRelease(service)
-        if let modelIdentifier = modelIdentifier {
-          return modelIdentifier
-        }
-      }
-    #endif
-    var systemInfo = utsname()
-    uname(&systemInfo)
-    let machineMirror = Mirror(reflecting: systemInfo.machine)
-    let identifier = machineMirror.children.reduce("") { identifier, element in
-      guard let value = element.value as? Int8, value != 0 else { return identifier }
-      return identifier + String(UnicodeScalar(UInt8(value)))
-    }
-    return identifier
-  }
-
-  /// from  https://github.com/TelemetryDeck/SwiftClient
-  static var operatingSystem: String {
-    #if os(macOS)
-      return "macOS"
-    #elseif os(iOS)
-      return "iOS"
-    #elseif os(watchOS)
-      return "watchOS"
-    #elseif os(tvOS)
-      return "tvOS"
-    #elseif os(visionOS)
-      return "visionOS"
-    #else
-      return "Unknown Operating System"
-    #endif
-  }
 }

--- a/Sources/FeedbackBulb/FeedbackEnvironmentObserver.swift
+++ b/Sources/FeedbackBulb/FeedbackEnvironmentObserver.swift
@@ -1,0 +1,92 @@
+//
+//  FeedbackEnvironmentObserver.swift
+//
+//
+//  Created by Konstantin Kostov on 19/02/2024.
+//
+
+import Foundation
+
+/// Helper class which offers methods to extract information about the current environment like OS and app version, device model and others.
+public final class FeedbackEnvironmentObserver {
+
+  /// Creates a new instance of `FeedbackEnvironmentObserver` which can be used to read default feedback attributes from the user's environment
+  public init() {}
+
+  /// Returns a list of attributes describing the current environment of the app.
+  public func describeCurrentEnvironment() -> [String: String] {
+    let osv = ProcessInfo.processInfo.operatingSystemVersion
+    let attrs = [
+      "app version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+        as? String ?? "-",
+      "app build": Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion")
+        as? String ?? "-",
+      "os": "\(osv.majorVersion).\(osv.minorVersion).\(osv.patchVersion)",
+      "system": Self.operatingSystem,
+      "model": Self.modelName,
+      "fbb.v": "1",
+    ]
+    return attrs
+  }
+
+  /// The modelname as reported by systemInfo.machine
+  /// implementation inspired by: https://github.com/TelemetryDeck/SwiftClient
+  private static var modelName: String {
+    #if os(iOS)
+      if #available(iOS 14.0, *) {
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+          var size = 0
+          sysctlbyname("hw.model", nil, &size, nil, 0)
+          var machine = [CChar](repeating: 0, count: size)
+          sysctlbyname("hw.model", &machine, &size, nil, 0)
+          return String(cString: machine)
+        }
+      }
+    #endif
+    #if os(macOS)
+      if #available(macOS 11, *) {
+        let service = IOServiceGetMatchingService(
+          kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+        var modelIdentifier: String?
+        if let modelData = IORegistryEntryCreateCFProperty(
+          service, "model" as CFString, kCFAllocatorDefault, 0
+        ).takeRetainedValue() as? Data {
+          if let modelIdentifierCString = String(data: modelData, encoding: .utf8)?.cString(
+            using: .utf8)
+          {
+            modelIdentifier = String(cString: modelIdentifierCString)
+          }
+        }
+        IOObjectRelease(service)
+        if let modelIdentifier = modelIdentifier {
+          return modelIdentifier
+        }
+      }
+    #endif
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineMirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = machineMirror.children.reduce("") { identifier, element in
+      guard let value = element.value as? Int8, value != 0 else { return identifier }
+      return identifier + String(UnicodeScalar(UInt8(value)))
+    }
+    return identifier
+  }
+
+  /// from  https://github.com/TelemetryDeck/SwiftClient
+  private static var operatingSystem: String {
+    #if os(macOS)
+      return "macOS"
+    #elseif os(iOS)
+      return "iOS"
+    #elseif os(watchOS)
+      return "watchOS"
+    #elseif os(tvOS)
+      return "tvOS"
+    #elseif os(visionOS)
+      return "visionOS"
+    #else
+      return "Unknown Operating System"
+    #endif
+  }
+}

--- a/Sources/FeedbackBulb/FeedbackSDKClient.swift
+++ b/Sources/FeedbackBulb/FeedbackSDKClient.swift
@@ -19,6 +19,7 @@ public struct FeedbackSDKClient {
   internal var session: URLSession
   internal let validStatusCodes = 200..<300
 
+  /// Creates a new instance of `FeedbackSDKClient` which can be used to submit feedback reports. You can provide your own URLSession which will be used to submit the report (e.g. in case of background submissions) and also customize the instance of Feedbackbulb which can receive the report.
   public init(
     appKey: String
   ) {
@@ -27,6 +28,7 @@ public struct FeedbackSDKClient {
     self.appKey = appKey
   }
 
+  /// Creates a new instance of `FeedbackSDKClient` which can be used to submit feedback reports.
   public init(
     appKey: String,
     session: URLSession = URLSession.shared,
@@ -154,6 +156,13 @@ extension FeedbackSDKClient {
 
 extension FeedbackSDKClient {
 
+  /// Submits a new feedback report with the provided content.
+  /// - Parameters:
+  ///   - content: The text form of a feedback report. Usually a user-provided comment.
+  ///   - attrs: A dictionary of string value attributes describing the environment of the user as well as the current state of the app. Attributes are visible in the feedback stream on feedbackbulb.com.
+  ///
+  ///  - Discussion:
+  ///   The attributes are not intended to include personally identifiable information
   public func submitFeedback(content: String, attrs: [String: String]? = nil) async throws {
     let req = HTTPRequestBuilder {
       $0.url = getURL(["api", "values"])
@@ -173,6 +182,17 @@ extension FeedbackSDKClient {
     let _ = try await fetch(req: req)
   }
 
+  /// Submits a new feedback report with the provided content and file attachment
+  /// - Parameters:
+  ///   - content: The text form of a feedback report. Usually a user-provided comment.
+  ///   - fileName: Name of the file attachment including the extension e.g. `screenshot.jpeg`
+  ///   - file: The contents of the file attachment. For example, the jpeg representation of an image.
+  ///   - mimeType: The mime type (written as a web Content-Type) of the attachment e.g."image/jpeg"
+  ///   - email: The email address of the user which can be used for email replies. Only include this if you have received informed opt-in concent from the user.
+  ///   - attrs: A dictionary of string value attributes describing the environment of the user as well as the current state of the app. Attributes are visible in the feedback stream on feedbackbulb.com.
+  ///
+  ///  - Discussion:
+  ///   The attributes are not intended to include personally identifiable information
   public func submitFeedback(
     content: String, fileName: String, file: Data? = nil, mimeType: String? = nil,
     email: String? = nil,

--- a/Sources/FeedbackBulb/HTTP/Decoder.swift
+++ b/Sources/FeedbackBulb/HTTP/Decoder.swift
@@ -4,6 +4,7 @@
 import Foundation
 
 internal final class FeedbackSDKDecoder: JSONDecoder {
+  /// Creates a new FeedbackSDKDecoder
   internal override init() {
     super.init()
     keyDecodingStrategy = .convertFromSnakeCase

--- a/Sources/FeedbackBulb/HTTP/Encoder.swift
+++ b/Sources/FeedbackBulb/HTTP/Encoder.swift
@@ -4,6 +4,7 @@
 import Foundation
 
 internal final class FeedbackSDKEncoder: JSONEncoder {
+  /// Creates a new instance of `FeedbackSDKEncoder`
   public override init() {
     super.init()
     keyEncodingStrategy = .convertToSnakeCase

--- a/Sources/FeedbackBulb/HTTP/MultipartForm/Data+Helpers.swift
+++ b/Sources/FeedbackBulb/HTTP/MultipartForm/Data+Helpers.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore: NoBlockComments
 /*
 Multipart support is provided by the https://github.com/davbeck/MultipartForm package which has been incorported as part of the source code of this library.
 

--- a/Sources/FeedbackBulb/HTTP/MultipartForm/MultipartForm.swift
+++ b/Sources/FeedbackBulb/HTTP/MultipartForm/MultipartForm.swift
@@ -1,3 +1,4 @@
+// swift-format-ignore: NoBlockComments
 /*
 Multipart support is provided by the https://github.com/davbeck/MultipartForm package which has been incorported as part of the source code of this library.
 

--- a/Sources/FeedbackBulb/Zofx.swift
+++ b/Sources/FeedbackBulb/Zofx.swift
@@ -1,6 +1,0 @@
-public struct FeedbackBulb {
-  public private(set) var text = "Hello, World!"
-
-  public init() {
-  }
-}


### PR DESCRIPTION
Adds `FeedbackEnvironmentObserver` which can be used by a client app to automatically include the default attributes for a feedback report (when client apps create their own UI)